### PR TITLE
[💬]Separando lógica de app en varios archivos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "discord.enabled": true
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,27 +1,19 @@
 
 import 'package:flutter/material.dart';
 
+import 'package:hope_contador_flutter/src/app.dart';
+
+//importaciones propias
+
+
+
+
+
 void main() {
 
-  runApp( new MyApp() );
+  runApp( MyApp() );
   
 }
 
 
 
-class MyApp extends StatelessWidget {
-
-
-@override
-Widget build(BuildContext context) {
-  return MaterialApp(
-    home: 
-    Center (
-     child: Text('Esto es una prueba') ,
-    ),
-  ) ;
-}
-
-
-
-}

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,0 +1,20 @@
+
+
+import 'package:flutter/material.dart';
+
+class MyApp extends StatelessWidget {
+
+
+@override
+Widget build(BuildContext context) {
+  return MaterialApp(
+    home: 
+    Center (
+     child: Text('Ocean Waves 🌊 ') ,
+    ),
+  ) ;
+}
+
+
+
+}


### PR DESCRIPTION
Se validó la forma de separar los archivos de nuestra app y la forma en que podemos llamar y enlazar los mismos en main.dart empleando la importación, se validó de forma manual estableciendo la ruta asi como de forma automatizada especificando el archivo que hacía falta en referencia y dejando que se genere la ruta por defecto automáticamente para la importación.